### PR TITLE
Avoid interp mock

### DIFF
--- a/lace_manager/data/data_MPGADGET.py
+++ b/lace_manager/data/data_MPGADGET.py
@@ -9,6 +9,7 @@ from lace_manager.data import data_PD2013
 from lace_manager.data import data_Chabanier2019
 from lace_manager.data import data_Karacayli_DESI
 from lace_manager.data import data_Karacayli_HIRES
+from lace.emulator import poly_p1d
 from lace.emulator import p1d_archive
 from lace_manager.emulator import test_simulation
 from lace.setup_simulations import read_genic
@@ -77,7 +78,7 @@ class P1D_MPGADGET(base_p1d_data.BaseDataP1D):
             print("Unknown data_cov_label",self.data_cov_label)
             quit()
 
-        k=data_file.k
+        k_kms=data_file.k
         z_data=data_file.z
 
         # setup TestSimulation object to read json files from sim directory
@@ -100,31 +101,32 @@ class P1D_MPGADGET(base_p1d_data.BaseDataP1D):
         # Get k_min for the sim data, & cut k values below that
         k_min_Mpc=self.mock_sim.k_Mpc[1]
         k_min_kms=k_min_Mpc/dkms_dMpc_zmin
-        Ncull=np.sum(k<k_min_kms)
-        k=k[Ncull:]
+        Ncull=np.sum(k_kms<k_min_kms)
+        k_kms=k_kms[Ncull:]
 
-        Pk=[]
+        Pk_kms=[]
         cov=[]
         ## Set P1D and covariance for each redshift
         for iz,z in enumerate(z_sim):
+            # convert Mpc to km/s
+            dkms_dMpc=sim_camb_results.hubble_parameter(z)/(1+z)
+            data_k_Mpc=k_kms*dkms_dMpc
+
             # store P1D in Mpc, except k=0
             if self.polyfit==True:
-                ## Get "smoothed" polyfit p1d
-                k_Mpc,p1d_Mpc=self.mock_sim.get_polyfit_p1d_Mpc(z,
-                            fit_kmax_Mpc=8)
-                p1d_Mpc=p1d_Mpc[1:]
-                k_Mpc=k_Mpc[1:]
+                # Get "smoothed" polyfit p1d
+                fit_p1d=poly_p1d.PolyP1D(self.mock_sim.k_Mpc,
+                            self.mock_sim.p1d_Mpc[iz],kmin_Mpc=1.e-3,
+                            kmax_Mpc=8,deg=4)
+                # evalute polyfit to data wavenumbers
+                sim_p1d_kms=fit_p1d.P_Mpc(data_k_Mpc)*dkms_dMpc
             else:
-                p1d_Mpc=np.asarray(self.mock_sim.p1d_Mpc[iz][1:])
-                k_Mpc=np.asarray(self.mock_sim.k_Mpc[1:])
-            conversion_factor=sim_camb_results.hubble_parameter(z)/(1+z)
-            
-            # evaluate P1D in data wavenumbers (in velocity units)
-            interpolator=interp1d(k_Mpc,p1d_Mpc,"cubic")
-            k_interp=k*conversion_factor
-            interpolated_P=interpolator(k_interp)
-            p1d_sim=interpolated_P*conversion_factor
-            Pk.append(p1d_sim)
+                sim_p1d_Mpc=np.asarray(self.mock_sim.p1d_Mpc[iz][1:])
+                sim_k_Mpc=np.asarray(self.mock_sim.k_Mpc[1:])
+                # evaluate P1D in data wavenumbers (in velocity units)
+                interp_sim_Mpc=interp1d(sim_k_Mpc,sim_p1d_Mpc,"cubic")
+                sim_p1d_kms=interp_sim_Mpc(data_k_Mpc)*dkms_dMpc
+            Pk_kms.append(sim_p1d_kms)
 
             # Now get covariance from the nearest z bin in data
             cov_mat=data_file.get_cov_iz(np.argmin(abs(z_data-z)))
@@ -132,7 +134,7 @@ class P1D_MPGADGET(base_p1d_data.BaseDataP1D):
             cov_mat=self.data_cov_factor*cov_mat[Ncull:,Ncull:]
             cov.append(cov_mat)
 
-        return z_sim,k,Pk,cov
+        return z_sim,k_kms,Pk_kms,cov
     
 
     def _set_true_values(self):

--- a/lace_manager/likelihood/likelihood.py
+++ b/lace_manager/likelihood/likelihood.py
@@ -757,7 +757,7 @@ class Likelihood(object):
         plt.plot(-10,-10,linestyle="-",label="Data",color="k")
         plt.plot(-10,-10,linestyle=":",label="Fit",color="k")
         plt.legend()
-        plt.xlabel('k_\parallel [s/km]')
+        plt.xlabel(r'$k_\parallel$ [s/km]')
         plt.xlim(min(k_kms)-0.001,max(k_kms)+0.001)
         plt.tight_layout()
         plt.show()


### PR DESCRIPTION
Instead of evaluating the polynomial at k_sim, and then interpolate to k_data, we can evaluate directly the polynomial at k_data.

The contours for the small test (Ohio mocks) look significantly better, so I'm testing this now at NERSC for a larger (compressed) run. 

@Chris-Pedersen , are you using the master branch for your compression project? If so we should be careful to clearly identify runs pre and post this change. Would you rather have an option in data_MPGadget that enables this new feature, and have it default to the old code for backward-compatibility?
